### PR TITLE
Fix typos

### DIFF
--- a/index.md
+++ b/index.md
@@ -9,7 +9,7 @@ Até onde sei, o único livro sobre Elixir em língua portuguesa é [Elixir: Do 
 
 ### Blogs 
 
-## Em atividade (ao menos uma postagem nos últimos 3 meses(
+## Em atividade (ao menos uma postagem nos últimos 3 meses)
 
 - [Willian Frantz](https://dev.to/wlsf)
 - [Elixir UTFPR](https://dev.to/elixir_utfpr)
@@ -52,4 +52,4 @@ Existe também um grupo com vários membros no Facebook:
 
 Quer contribuir com novos itens e categorias? Faça um *pull request* ou entre em contato com [@adolfont no Twitter](https://twitter.com/adolfont).
 
-Uma lista de recursos em portugu~es está em [Recursos sobre Elixir em português](https://github.com/adolfont/elixir_cop/blob/master/resources/portuguese.md).
+Uma lista de recursos em português está em [Recursos sobre Elixir em português](https://github.com/adolfont/elixir_cop/blob/master/resources/portuguese.md).


### PR DESCRIPTION
Sugestão de correções de typos na escrita do index.md

**Parênteses** aberta:
<img width="584" alt="Screen Shot 2020-11-29 at 13 42 21" src="https://user-images.githubusercontent.com/5873073/100548007-b6bff680-3248-11eb-85d2-8952bfc586f8.png">

Acento em **português**:
<img width="600" alt="Screen Shot 2020-11-29 at 13 42 33" src="https://user-images.githubusercontent.com/5873073/100548015-bd4e6e00-3248-11eb-9a06-f0bd28b17f22.png">
